### PR TITLE
fix test and return ct lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
             echo "::set-output name=changed::true"
           fi
 
-          #      - name: Run chart lint
-        #        run: ct lint --debug
+      - name: Run chart lint
+        run: ct lint --debug
 
       - name: Run chart unittest
         run: |

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aspecto-io-opentelemetry-collector
-version: '1.3.4'
+version: '1.3.5'
 home: https://aspecto.io
 type: application
 description: helm chart of aspecto's opentelemetry tail sampling collector

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -344,7 +344,6 @@ receiver:
             protocol: TCP
             loadBalancer:
               simple:
-              
 collector:
   image:
     repository: ''
@@ -618,7 +617,6 @@ collector:
             protocol: TCP
             loadBalancer:
               simple:
-              
           - name: jaeger-grpc
             type: TCP
             externalPort: 14250
@@ -626,7 +624,6 @@ collector:
             protocol: TCP
             loadBalancer:
               simple:
-              
           - name: jaeger-http
             type: http
             externalPort: 14268


### PR DESCRIPTION
due to some issues i had to remove the lint as I couldn't find the source of the lint errors (it was trailing spaces) 
I've found the issue and now the tests can be set back on ! 