### PR TITLE
move object type from int to string

### DIFF
--- a/charts/opentelemetry-collector/values.schema.json
+++ b/charts/opentelemetry-collector/values.schema.json
@@ -492,7 +492,7 @@
                                     "type": "object",
                                     "properties": {
                                         "cpu": {
-                                            "type": "number",
+                                            "type": "string",
                                             "default": 2,
                                             "description": "Max number of cores to allocate"
                                         },
@@ -507,7 +507,7 @@
                                     "type": "object",
                                     "properties": {
                                         "cpu": {
-                                            "type": "number",
+                                            "type": "string",
                                             "default": 2,
                                             "description": "Number of cores to allocate"
                                         },
@@ -1071,7 +1071,7 @@
                                     "type": "object",
                                     "properties": {
                                         "cpu": {
-                                            "type": "number",
+                                            "type": "string",
                                             "default": 2,
                                             "description": "Max number of cores to allocate"
                                         },
@@ -1086,7 +1086,7 @@
                                     "type": "object",
                                     "properties": {
                                         "cpu": {
-                                            "type": "number",
+                                            "type": "string",
                                             "default": 2,
                                             "description": "Number of cores to allocate"
                                         },

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -173,10 +173,10 @@ receiver:
 
     resources:
       limits:
-        cpu: 2
+        cpu: '2'
         memory: 2Gi
       requests:
-        cpu: 1
+        cpu: '1'
         memory: 1Gi
 
     probe:
@@ -471,10 +471,10 @@ collector:
 
     resources:
       limits:
-        cpu: 2
+        cpu: '2'
         memory: 2Gi
       requests:
-        cpu: 1
+        cpu: '1'
         memory: 1Gi
 
     probe:


### PR DESCRIPTION
support cpu as string value instead of numeric