### PR TITLE
fix: receiver dns lookup returns only one IP

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: aspecto-io-opentelemetry-collector
-version: '1.4.3'
+version: '1.4.4'
 home: https://aspecto.io
 type: application
 description: helm chart of aspecto's opentelemetry tail sampling collector

--- a/charts/opentelemetry-collector/templates/collector/service.yaml
+++ b/charts/opentelemetry-collector/templates/collector/service.yaml
@@ -27,6 +27,7 @@ metadata:
   {{- if $localObjectAnnotations }}{{ toYaml $localObjectAnnotations | nindent 4 }}{{- end }}
 spec:
   type: {{ .serviceType }}
+  clusterIP: None
   ports:
     {{- range .ports }}
     - port: {{ .externalPort }}

--- a/charts/opentelemetry-collector/templates/collector/service.yaml
+++ b/charts/opentelemetry-collector/templates/collector/service.yaml
@@ -27,7 +27,9 @@ metadata:
   {{- if $localObjectAnnotations }}{{ toYaml $localObjectAnnotations | nindent 4 }}{{- end }}
 spec:
   type: {{ .serviceType }}
+  {{- if eq .serviceType "ClusterIP" }}
   clusterIP: None
+  {{- end }}
   ports:
     {{- range .ports }}
     - port: {{ .externalPort }}


### PR DESCRIPTION
use `clusterIP: None` to make the collector a headless service so we can get all IPs of pods when doing a DNS lookup.